### PR TITLE
fixing cache function definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,7 @@ interface InitOptions extends DetectorOptions {
 }
 
 interface LanguageDetector {
-  cache?(lng: string, options: DetectorOptions): void;
+  cache?(lng: string, caches?: string[]): void;
   detect(detectionOrders?: string | string[]): string | undefined;
 }
 export default function LanguageDetector(options: InitOptions): LanguageDetector


### PR DESCRIPTION
Fixing the 2nd parameter of the cache function to match the I18nextBrowserLanguageDetector definition: https://github.com/i18next/i18next-browser-languageDetector/blob/060d1f98a49bc38c83eaaf7a8399e08757af8e9d/index.d.ts#L84